### PR TITLE
COOK-2217 Let people update the email conf property using node attributes

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,0 +1,19 @@
+#
+# Cookbook Name:: fail2ban
+# Attributes:: default
+#
+# Copyright 2010, Opscode, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+default["fail2ban"]["email"] = 'root@localhost'

--- a/templates/default/jail.conf.erb
+++ b/templates/default/jail.conf.erb
@@ -31,7 +31,7 @@ backend = polling
 #
 # Destination email address used solely for the interpolations in
 # jail.{conf,local} configuration files.
-destemail = root@localhost
+destemail = <%= node['fail2ban']['email'] %>
 
 #
 # ACTIONS


### PR DESCRIPTION
Changed jail.conf.erb to get the email from node['fail2ban']['email'] instead of being hardcoded, and set the old value (root@localhost) to the default in attributes/default.rb.
