### PR TITLE
Cook 2592: Update to 0.8.4 jail config for template and add additional attributes

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -27,7 +27,12 @@ default['fail2ban']['syslog_target'] = "/var/log/fail2ban.log"
 default['fail2ban']['syslog_facility'] = "1"
 
 # jail.conf configuration options
+default['fail2ban']['ignoreip'] = "127.0.0.1/8"
 default['fail2ban']['bantime'] = 300
 default['fail2ban']['maxretry'] = 5
-default['fail2ban']['email'] = 'root@localhost'
 default['fail2ban']['backend'] = 'polling'
+default['fail2ban']['email'] = 'root@localhost'
+default['fail2ban']['banaction'] = 'iptables-multiport'
+default['fail2ban']['mta'] = 'sendmail'
+default['fail2ban']['protocol'] = 'tcp'
+default['fail2ban']['chain'] = 'INPUT'

--- a/templates/default/jail.conf.erb
+++ b/templates/default/jail.conf.erb
@@ -18,7 +18,7 @@
 [DEFAULT]
 
 # "ignoreip" can be an IP address, a CIDR mask or a DNS host
-ignoreip = 127.0.0.1/8
+ignoreip = <%= node['fail2ban']['ignoreip']  %>
 bantime  = <%= node['fail2ban']['bantime'] %>
 maxretry = <%= node['fail2ban']['maxretry'] %>
 
@@ -41,18 +41,18 @@ destemail = <%= node['fail2ban']['email'] %>
 # iptables-multiport, shorewall, etc) It is used to define
 # action_* variables. Can be overridden globally or per
 # section within jail.local file
-banaction = iptables-multiport
+banaction = <%= node['fail2ban']['banaction'] %>
 
 # email action. Since 0.8.1 upstream fail2ban uses sendmail
 # MTA for the mailing. Change mta configuration parameter to mail
 # if you want to revert to conventional 'mail'.
-mta = sendmail
+mta = <%= node['fail2ban']['mta'] %>
 
 # Default protocol
-protocol = tcp
+protocol = <%= node['fail2ban']['protocol'] %>
 
 # Specify chain where jumps would need to be added in iptables-* actions
-chain = INPUT
+chain = <%= node['fail2ban']['chain'] %>
 
 #
 # Action shortcuts. To be used to define action parameter


### PR DESCRIPTION
Now the config file we template matches what the distros have shipped for a while.  I also added additional attributes so it's less likely that this file needs to be customized by the user.
