### PR TITLE
[COOK-2748] Handle /etc.init.d/fail2ban status for older versions

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -39,4 +39,10 @@ end
 service "fail2ban" do
   supports [ :status => true, :restart => true ]
   action [ :enable, :start ]
+
+  if (platform?("ubuntu") && node["platform_version"].to_f < 12.04) ||
+     (platform?("debian") && node["platform_version"].to_f < 7)
+      # status command returns non-0 value only since fail2ban 0.8.6-3 (Debian)
+      status_command '/etc/init.d/fail2ban status | grep -q "is running"'
+  end
 end


### PR DESCRIPTION
http://tickets.opscode.com/browse/COOK-2748

Fail2ban versions before 0.8.6-3 (for Debian) always return exit code 0 for the status command, even if the service is not running. This was fixed in newer versions which now return proper exit codes. It was fixed in fail2ban in https://github.com/fail2ban/fail2ban/pull/36.

It is probably a good idea to also check the other supported platform, but this pull request makes the status check work properly at least on all Ubuntu and Debian versions.
