### PR TITLE
Allow action w/override in service declaration

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -32,6 +32,7 @@ default['fail2ban']['bantime'] = 300
 default['fail2ban']['maxretry'] = 5
 default['fail2ban']['backend'] = 'polling'
 default['fail2ban']['email'] = 'root@localhost'
+default['fail2ban']['action'] = 'action_'
 default['fail2ban']['banaction'] = 'iptables-multiport'
 default['fail2ban']['mta'] = 'sendmail'
 default['fail2ban']['protocol'] = 'tcp'

--- a/templates/default/jail.conf.erb
+++ b/templates/default/jail.conf.erb
@@ -72,7 +72,7 @@ action_mwl = %(banaction)s[name=%(__name__)s, port="%(port)s", protocol="%(proto
 # Choose default action.  To change, just override value of 'action' with the
 # interpolation to the chosen action shortcut (e.g.  action_mw, action_mwl, etc) in jail.local
 # globally (section [DEFAULT]) or per specific section
-action = %(action_)s
+action = %(<%= node['fail2ban']['action'] %>)s
 
 #
 # JAILS
@@ -101,6 +101,9 @@ logpath = <%= param['logpath'] %>
 maxretry = <%= param['maxretry'] %>
 <% if param['protocol'] %>
 protocol = <%= param['protocol'] %>
+<% end %>
+<% if param['action'] %>
+action = %(<%= param['action'] %>)s
 <% end %>
 <% if param['banaction'] %>
 banaction = <%= param['banaction'] %>


### PR DESCRIPTION
The jail.conf template defines 3 separate actions but no way to override
the default action or any action per service, despite the instructions.

Adding a new attribute for action and render action if specified within
a service definition.

Fixes https://tickets.opscode.com/browse/COOK-3899
