### PR TITLE
Fix small typo in README.md for smtp

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ default['fail2ban']['services'] = {
      },
   'smtp' => {
         "enabled" => "true",
-        "port" => "smpt",
+        "port" => "smtp",
         "filter" => "smtp",
         "logpath" => node['fail2ban']['auth_log'],
         "maxretry" => "6"


### PR DESCRIPTION
There is a small typo in the README on the SMTP port. If someone were to copy and paste the example it might be easily missed.
