### PR TITLE
COOK-4690 don't force yum cookbooks as dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@ fail2ban Cookbook CHANGELOG
 ===========================
 This file is used to list changes made in each version of the fail2ban cookbook.
 
+v2.1.3
+------
+### Improvement
+- **[COOK-4690](https://tickets.opscode.com/browse/COOK-4690)** - Don't force yum cookbooks as dependency
 
 v2.1.2
 ------

--- a/metadata.rb
+++ b/metadata.rb
@@ -7,8 +7,8 @@ version           '2.1.3'
 
 recipe 'fail2ban', 'Installs and configures fail2ban'
 
-depends 'yum', '~> 3.0'
-depends 'yum-epel'
+recommends 'yum', '~> 3.0'
+recommends 'yum-epel'
 
 %w{ debian ubuntu redhat centos scientific amazon oracle }.each do |os|
   supports os


### PR DESCRIPTION
On Ubuntu/Debian if there is no 'yum' cookbook knife throws an error during cookbook upload

<pre>ERROR: Cookbook fail2ban depends on cookbook 'yum' version '~> 3.0',
ERROR: which is not currently being uploaded and cannot be found on the server.</pre>


PS> I'm signed CLA, it was trivial but didn't apply to 'Obvious Fix'
