### PR TITLE
Add Pidfile attribute to fail2ban.config

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -20,6 +20,7 @@
 default['fail2ban']['loglevel'] = 3
 default['fail2ban']['socket'] = '/var/run/fail2ban/fail2ban.sock'
 default['fail2ban']['logtarget'] = '/var/log/fail2ban.log'
+default['fail2ban']['pidfile'] = '/var/run/fail2ban/fail2ban.pid'
 
 # These values will only be printed to fail2ban.conf
 # if node['fail2ban']['logtarget'] is set to 'SYSLOG'

--- a/templates/default/fail2ban.conf.erb
+++ b/templates/default/fail2ban.conf.erb
@@ -35,3 +35,10 @@ syslog-facility = <%= node['fail2ban']['syslog_facility'] %>
 # Values: FILE  Default:  /var/run/fail2ban/fail2ban.sock
 #
 socket = <%= node['fail2ban']['socket'] %>
+
+# Option: pidfile
+# Notes.: Set the PID file. This is used to store the process ID of the
+#         fail2ban server.
+# Values: [ FILE ]  Default: /var/run/fail2ban/fail2ban.pid
+#
+pidfile = <%= node['fail2ban']['pidfile'] %>


### PR DESCRIPTION
I found this commit in @szymonpk's fork, where @stuszynski fixed #20. I'm just turning this into a pull request.
