### PR TITLE
Add default value for pidfile

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -20,6 +20,7 @@
 default['fail2ban']['loglevel'] = 3
 default['fail2ban']['socket'] = '/var/run/fail2ban/fail2ban.sock'
 default['fail2ban']['logtarget'] = '/var/log/fail2ban.log'
+default['fail2ban']['pidfile'] = '/var/run/fail2ban/fail2ban.pid'
 
 # These values will only be printed to fail2ban.conf
 # if node['fail2ban']['logtarget'] is set to 'SYSLOG'

--- a/templates/default/fail2ban.conf.erb
+++ b/templates/default/fail2ban.conf.erb
@@ -35,3 +35,10 @@ syslog-facility = <%= node['fail2ban']['syslog_facility'] %>
 # Values: FILE  Default:  /var/run/fail2ban/fail2ban.sock
 #
 socket = <%= node['fail2ban']['socket'] %>
+
+# Option: pidfile
+# Notes.: Set the PID file. This is used to store the process ID of the
+#         fail2ban server.
+# Values: [ FILE ]  Default: /var/run/fail2ban/fail2ban.pid
+#
+pidfile = <%= node['fail2ban']['pidfile'] %>


### PR DESCRIPTION
The following warning is issued during fail2ban log rotation (and also during fail2ban start/stop):

```
/etc/cron.daily/logrotate:
WARNING 'pidfile' not defined in 'Definition'. Using default one: '/var/run/fail2ban/fail2ban.pid'
```

... due to this line in /etc/logrotate.d/fail2ban:

```
fail2ban-client set logtarget /var/log/fail2ban.log >/dev/null
```

In order to suppress this warning, this pull request simply adds a default pidfile entry in /etc/fail2ban/fail2ban.conf.
