### PR TITLE
Implements Slack notifications as an option

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,20 @@ default['fail2ban']['filters'] = {
 }
 ```
 
+In the case you would like to get Slack notifications on IP addresses banned/unbanned, this cookbook supports it by setting the following attributes:
+
+```ruby
+# A Slack webhook looks like this:
+# https://hooks.slack.com/services/A123BCD4E/FG5HI6KLM/7n8opqrsT9UVWxyZ0AbCdefG
+default['fail2ban']['slack_webhook'] = nil
+# Then setting the Slack channel name without the hashtag (#)
+default['fail2ban']['slack_channel'] = 'general'
+```
+
+Then you will get notifications like this:
+
+> [hostname] Banned 🇳🇬 217.117.13.12 in the jail sshd after 5 attempts
+
 Issues related to rsyslog
 ==========================
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -38,6 +38,15 @@ default['fail2ban']['banaction'] = 'iptables-multiport'
 default['fail2ban']['mta'] = 'sendmail'
 default['fail2ban']['protocol'] = 'tcp'
 default['fail2ban']['chain'] = 'INPUT'
+# Create and copy/past your Slack webhook in the following attribute and you'll
+# get Slack message on banning/unbanning IP like this:
+# [hostname] Banned 🇳🇬 217.117.13.12 in the jail sshd after 5 attempts
+#
+# A Slack webhook looks like this:
+# https://hooks.slack.com/services/A123BCD4E/FG5HI6KLM/7n8opqrsT9UVWxyZ0AbCdefG
+default['fail2ban']['slack_webhook'] = nil
+# Then setting the Slack channel name without the hashtag (#)
+default['fail2ban']['slack_channel'] = 'general'
 
 # Using attributes to specify the fail2ban filters is now deprecated in favor
 # of the fail2ban_filter resource which provides a more Chef native way of defining

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -25,6 +25,13 @@ package 'fail2ban' do
   notifies :reload, 'ohai[reload package list]', :immediately
 end
 
+if node['fail2ban']['slack_webhook']
+  package 'curl' do
+    action :install
+    notifies :reload, 'ohai[reload package list]', :immediately
+  end
+end
+
 ohai 'reload package list' do
   plugin 'packages'
   action :nothing
@@ -33,7 +40,10 @@ end
 node['fail2ban']['filters'].each do |name, options|
   template "/etc/fail2ban/filter.d/#{name}.conf" do
     source 'filter.conf.erb'
-    variables(failregex: [options['failregex']].flatten, ignoreregex: [options['ignoreregex']].flatten)
+    variables(
+      failregex: [options['failregex']].flatten,
+      ignoreregex: [options['ignoreregex']].flatten
+    )
     notifies :restart, 'service[fail2ban]'
   end
 end
@@ -46,7 +56,29 @@ end
 
 template '/etc/fail2ban/jail.local' do
   source 'jail.conf.erb'
+  variables(
+    slack_webhook: node['fail2ban']['slack_webhook']
+  )
   notifies :restart, 'service[fail2ban]'
+end
+
+if node['fail2ban']['slack_webhook']
+  template '/etc/fail2ban/action.d/slack.conf' do
+    source 'slack.conf.erb'
+    notifies :restart, 'service[fail2ban]'
+  end
+
+  template '/etc/fail2ban/slack_notify.sh' do
+    source 'slack_notify.sh.erb'
+    owner 'root'
+    group 'root'
+    mode '0750'
+    variables(
+      slack_channel: node['fail2ban']['slack_channel'],
+      slack_webhook: node['fail2ban']['slack_webhook']
+    )
+    notifies :restart, 'service[fail2ban]'
+  end
 end
 
 file '/etc/fail2ban/jail.d/defaults-debian.conf' do

--- a/spec/unit/recipes/default_spec.rb
+++ b/spec/unit/recipes/default_spec.rb
@@ -9,13 +9,20 @@ describe 'fail2ban::default converge' do
         'ignoreregex' => [],
       },
     }
-    runner.node.normal['packages']['fail2ban'] = { version: '0.9.3-1', arch: 'all' }
+    runner.node.normal['packages']['fail2ban'] = {
+      version: '0.9.3-1',
+      arch: 'all',
+    }
 
     runner.converge('fail2ban::default')
   end
 
   it 'installs the fail2ban package' do
     expect(chef_run).to install_package('fail2ban')
+  end
+
+  it 'should not install the curl package' do
+    expect(chef_run).to_not install_package('curl')
   end
 
   it 'should template fail2ban.conf' do
@@ -25,8 +32,10 @@ describe 'fail2ban::default converge' do
     }
   end
 
-  it 'should template jail.local' do
-    expect(chef_run).to render_file('/etc/fail2ban/jail.local')
+  it 'should template jail.local with the default action' do
+    expect(chef_run).to render_file('/etc/fail2ban/jail.local').with_content { |content|
+      expect(content).to match(/^action = %\(action_\)s/)
+    }
   end
 
   it 'reload service on config change' do
@@ -36,5 +45,86 @@ describe 'fail2ban::default converge' do
 
   it 'templates filter.d file when attribute set' do
     expect(chef_run).to render_file('/etc/fail2ban/filter.d/nginx-proxy.conf')
+  end
+
+  it 'should not templates action.d file' do
+    expect(chef_run).to_not render_file('/etc/fail2ban/action.d/slack.conf')
+  end
+
+  it 'should not templates slack script file' do
+    expect(chef_run).to_not render_file('/etc/fail2ban/slack_notify.sh')
+  end
+end
+
+describe 'fail2ban::default converge with a given slack webhook' do
+  let(:chef_run) do
+    runner = ChefSpec::ServerRunner.new(platform: 'ubuntu', version: '16.04')
+    runner.node.normal['fail2ban'] = {
+      filters: {
+        'nginx-proxy' => {
+          'failregex' => ['^<HOST> -.*GET http.*'],
+          'ignoreregex' => [],
+        },
+      },
+      slack_channel: 'infra',
+      slack_webhook: 'https://hooks.slack.com/services/A123BCD4E/FG5HI6KLM/7n8opqrsT9UVWxyZ0AbCdefG',
+    }
+    runner.node.normal['packages']['fail2ban'] = {
+      version: '0.9.3-1',
+      arch: 'all',
+    }
+
+    runner.converge('fail2ban::default')
+  end
+
+  it 'installs the fail2ban package' do
+    expect(chef_run).to install_package('fail2ban')
+  end
+
+  it 'should install the curl package' do
+    expect(chef_run).to install_package('curl')
+  end
+
+  it 'should template fail2ban.conf' do
+    expect(chef_run).to render_file('/etc/fail2ban/fail2ban.conf').with_content { |content|
+      expect(content).to match(/^loglevel = INFO/)
+      expect(content).to match(/^dbpurgeage = 86400/)
+    }
+  end
+
+  it 'should template jail.local with the Slack action' do
+    expect(chef_run).to render_file('/etc/fail2ban/jail.local').with_content { |content|
+      expect(content).to match(/^action_with_slack_notification =/)
+      expect(content).to match(/^\s+slack\[name=%\(__name__\)s\]/)
+      expect(content).to match(/^action = %\(action_with_slack_notification\)s/)
+    }
+  end
+
+  it 'reload service on config change' do
+    resource = chef_run.template('/etc/fail2ban/fail2ban.conf')
+    expect(resource).to notify('service[fail2ban]').to(:restart)
+  end
+
+  it 'should templates filter.d file when attribute set' do
+    expect(chef_run).to render_file('/etc/fail2ban/filter.d/nginx-proxy.conf')
+  end
+
+  it 'should templates action.d file' do
+    expect(chef_run).to render_file('/etc/fail2ban/action.d/slack.conf')
+  end
+
+  it 'should templates slack script file' do
+    expect(chef_run).to render_file('/etc/fail2ban/slack_notify.sh').with_content { |content|
+      expect(content).to match(%r{HOOK_URL=https://hooks.slack.com/services/A123BCD4E/FG5HI6KLM/7n8opqrsT9UVWxyZ0AbCdefG})
+      expect(content).to match(/CHANNEL="#infra"/)
+    }
+  end
+
+  it 'should create the slack script with the correct attributes' do
+    expect(chef_run).to create_template('/etc/fail2ban/slack_notify.sh').with(
+      owner: 'root',
+      group: 'root',
+      mode: '0755'
+    )
   end
 end

--- a/templates/jail.conf.erb
+++ b/templates/jail.conf.erb
@@ -71,10 +71,15 @@ action_mw = %(banaction)s[name=%(__name__)s, port="%(port)s", protocol="%(protoc
 action_mwl = %(banaction)s[name=%(__name__)s, port="%(port)s", protocol="%(protocol)s", chain="%(chain)s"]
                %(mta)s-whois-lines[name=%(__name__)s, dest="%(destemail)s", logpath=%(logpath)s, chain="%(chain)s", sendername="%(sendername)s"]
 
+<% if @slack_webhook %>
+action_with_slack_notification = %(banaction)s[name=%(__name__)s, bantime="%(bantime)s", port="%(port)s", protocol="%(protocol)s", chain="%(chain)s"]
+                                 slack[name=%(__name__)s]
+<% end %>
+
 # Choose default action.  To change, just override value of 'action' with the
 # interpolation to the chosen action shortcut (e.g.  action_mw, action_mwl, etc) in jail.local
 # globally (section [DEFAULT]) or per specific section
-action = %(<%= node['fail2ban']['action'] %>)s
+action = %(<%= @slack_webhook ? 'action_with_slack_notification' : node['fail2ban']['action'] %>)s
 
 #
 # JAILS

--- a/templates/slack.conf.erb
+++ b/templates/slack.conf.erb
@@ -1,0 +1,4 @@
+[Definition]
+
+actionban = /bin/bash /etc/fail2ban/slack_notify.sh "Banned _country_ <ip> in the jail <name> after <failures> attempts" "<ip>" > /dev/null 2>&1
+actionunban = /bin/bash /etc/fail2ban/slack_notify.sh "Unbanned _country_ <ip> in the jail <name>" "<ip>" > /dev/null 2>&1

--- a/templates/slack_notify.sh.erb
+++ b/templates/slack_notify.sh.erb
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+# message first command argument
+MESSAGE=$1
+HOOK_URL=<%= @slack_webhook %>
+HOST=$(hostname)
+
+CHANNEL="#<%= @slack_channel %>"
+USERNAME="fail2ban"
+ICON=":cop:"
+
+# ip second command argument
+IP=$2
+# lets find out from what country we have our hacker
+COUNTRY=$(curl ipinfo.io/${IP}/country)
+# converting country to lover case. I love you bash script =\
+COUNTRY=$(echo "$COUNTRY" | tr -s  '[:upper:]'  '[:lower:]')
+# slack emoji
+COUNTRY=":flag-$COUNTRY:"
+
+# replace _country_ template to the country emoji
+MESSAGE="${MESSAGE/_country_/$COUNTRY}"
+
+curl -X POST --data-urlencode "payload={\"channel\": \"${CHANNEL}\", \"username\": \"${USERNAME}\", \"text\": \"[${HOST}] ${MESSAGE}\", \"icon_emoji\": \"${ICON}\"}" ${HOOK_URL}
+
+exit 0


### PR DESCRIPTION
### Description

By setting the `default['fail2ban']['slack_webhook']` and `default['fail2ban']['slack_channel']` attributes, the recipe will add necessary stuff to get notifications in slack when an IP address is banned and unbanned.
Example of Slack notification message: "[hostname] Banned 🇳🇬 217.117.13.12 in the jail sshd after 5 attempts"

Signed-off-by: Guillaume Hain <guillaume@pharmony.lu>

### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
