### PR TITLE
Remove deprecated platform in spec tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+- Remove deprecated platform in spec tests
+
 ## 6.2.1 (2020-05-05)
 
 - Migrated build system to github actions for testing

--- a/spec/unit/recipes/centos_spec.rb
+++ b/spec/unit/recipes/centos_spec.rb
@@ -1,27 +1,5 @@
 require 'spec_helper'
 
-describe 'default recipe on CentOS 5' do
-  let(:chef_run) do
-    runner = ChefSpec::ServerRunner.new(platform: 'centos', version: '5.11')
-    runner.node.default['packages']['fail2ban'] = {
-      epoch: '0',
-      version: '0.8.14',
-      release: '1.el5',
-      installdate: '1409547600',
-      arch: 'noarch',
-    }
-    runner.converge('fail2ban::default')
-  end
-
-  it 'converges successfully' do
-    expect { :chef_run }.to_not raise_error
-  end
-
-  it 'should template fail2ban.conf' do
-    expect(chef_run).to render_file('/etc/fail2ban/fail2ban.conf').with_content(/^loglevel = 3/)
-  end
-end
-
 describe 'default recipe on CentOS 6' do
   let(:chef_run) do
     runner = ChefSpec::ServerRunner.new(platform: 'centos', version: '6')


### PR DESCRIPTION
# Description

Remove deprecated platform in spec tests

## Issues Resolved

#88 

## Check List

- [x] All tests pass. See TESTING.md for details.
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable.
