### PR TITLE
Bugfix/jailresource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 6.2.2
+
+- fixed wrong property in `fail2ban_jail` and `fail2ban_filter` resources
+- added documentation for above changes
+
 ## Unreleased
 
 - Remove deprecated platform in spec tests

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 
 - Remove deprecated platform in spec tests
-
-## 6.2.2
-
 - fixed wrong property in `fail2ban_jail` and `fail2ban_filter` resources
 - added documentation for above changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,14 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+- Remove deprecated platform in spec tests
+
 ## 6.2.2
 
 - fixed wrong property in `fail2ban_jail` and `fail2ban_filter` resources
 - added documentation for above changes
-
-## Unreleased
-
-- Remove deprecated platform in spec tests
 
 ## 6.2.1 (2020-05-05)
 

--- a/README.md
+++ b/README.md
@@ -124,9 +124,11 @@ Then you will get notifications like this:
 There are 2 resources you can use to create `fail2ban_filter` and `fail2ban_jail`.
 
 ### fail2ban_filter
+
 The filter resource manages custom filters that are stored in `/etc/fail2ban/filters.d/`.
 
 #### Parameters
+
 fail2ban_filter accepts the following parameters:
 
 - failregex
@@ -142,9 +144,11 @@ end
 ```
 
 ### fail2ban_jail
+
 The filter resource manages custom jail definitions that are stored in `/etc/fail2ban/jail.d/`.
 
 ### Parameters
+
 fail2ban_jail accepts the following parameters:
 
 - filter - Name of the filter to be used by the jail to detect matches.

--- a/README.md
+++ b/README.md
@@ -119,7 +119,6 @@ Then you will get notifications like this:
 
 > [hostname] Banned 🇳🇬 217.117.13.12 in the jail sshd after 5 attempts
 
-
 ## Resources
 
 There are 2 resources you can use to create `fail2ban_filter` and `fail2ban_jail`.
@@ -130,8 +129,8 @@ The filter resource manages custom filters that are stored in `/etc/fail2ban/fil
 #### Parameters
 fail2ban_filter accepts the following parameters:
 
-* failregex
-* ignoreregex
+- failregex
+- ignoreregex
 
 Example:
 
@@ -148,12 +147,12 @@ The filter resource manages custom jail definitions that are stored in `/etc/fai
 ### Parameters
 fail2ban_jail accepts the following parameters:
 
-* filter - Name of the filter to be used by the jail to detect matches.
-* logpath -  Path to the log file which is provided to the filter 
-* protocol - Protocol type [tcp, udp, all]. TCP Default.
-* ports - An array of port(s) to watch.
-* maxretry - Number of matches which triggers ban action.
-* ignoreips - An array of IPs to ignore.
+- filter - Name of the filter to be used by the jail to detect matches.
+- logpath -  Path to the log file which is provided to the filter.
+- protocol - Protocol type [tcp, udp, all]. TCP Default.
+- ports - An array of port(s) to watch.
+- maxretry - Number of matches which triggers ban action.
+- ignoreips - An array of IPs to ignore.
 
 Example:
 

--- a/README.md
+++ b/README.md
@@ -119,6 +119,53 @@ Then you will get notifications like this:
 
 > [hostname] Banned 🇳🇬 217.117.13.12 in the jail sshd after 5 attempts
 
+
+## Resources
+
+There are 2 resources you can use to create `fail2ban_filter` and `fail2ban_jail`.
+
+### fail2ban_filter
+The filter resource manages custom filters that are stored in `/etc/fail2ban/filters.d/`.
+
+#### Parameters
+fail2ban_filter accepts the following parameters:
+
+* failregex
+* ignoreregex
+
+Example:
+
+```
+fail2ban_filter 'webmin-auth' do
+  failregex ["^%(__prefix_line)sNon-existent login as .+ from <HOST>\s*$",
+             "^%(__prefix_line)sInvalid login as .+ from <HOST>\s*$"]
+end
+```
+
+### fail2ban_jail
+The filter resource manages custom jail definitions that are stored in `/etc/fail2ban/jail.d/`.
+
+### Parameters
+fail2ban_jail accepts the following parameters:
+
+* filter - Name of the filter to be used by the jail to detect matches.
+* logpath -  Path to the log file which is provided to the filter 
+* protocol - Protocol type [tcp, udp, all]. TCP Default.
+* ports - An array of port(s) to watch.
+* maxretry - Number of matches which triggers ban action.
+* ignoreips - An array of IPs to ignore.
+
+Example:
+
+```
+fail2ban_jail 'ssh' do
+  ports %w(ssh)
+  filter 'sshd'
+  logpath node['fail2ban']['auth_log']
+  maxretry 3
+end
+```
+
 ## Issues related to rsyslog
 
 If you are using rsyslog parameter "$RepeatedMsgReduction on" in rsyslog.conf file

--- a/resources/filter.rb
+++ b/resources/filter.rb
@@ -27,7 +27,7 @@ property :ignoreregex, [String, Array]
 action :create do
   template "/etc/fail2ban/filter.d/#{new_resource.filter}.conf" do
     cookbook new_resource.cookbook
-    source new_resource.filter
+    source new_resource.source
     owner 'root'
     group 'root'
     mode '0644'

--- a/resources/jail.rb
+++ b/resources/jail.rb
@@ -19,6 +19,7 @@
 #
 
 property :jail, String, name_property: true
+property :filter, String
 property :source, String, default: 'jail.erb'
 property :cookbook, String, default: 'fail2ban'
 property :logpath, String
@@ -26,11 +27,12 @@ property :protocol, String
 property :ports, Array, default: []
 property :maxretry, Integer
 property :ignoreips, Array
+property :priority, [String, Integer], default: '50'
 
 action :create do
-  template "/etc/fail2ban/jail.d/50-#{new_resource.jail}.conf" do
+  template "/etc/fail2ban/jail.d/#{new_resource.priority}-#{new_resource.jail}.conf" do
     cookbook new_resource.cookbook
-    source new_resource.filter
+    source new_resource.source
     owner 'root'
     group 'root'
     mode '0644'


### PR DESCRIPTION
# Description

This change fixes the incorrect property values in the two resources `jail` and `filter`. It also adds documentation.

One of the things this also does is allows the ability to pass a "priority" to the `jail` resource so that files can be named `#{new_resource.priority}-#{new_resource.jail}`.
But, I don't think this is needed? I can't find documentation about Fail2Ban setting jails based on priority.

## Issues Resolved

https://github.com/sous-chefs/fail2ban/issues/60
https://github.com/sous-chefs/fail2ban/issues/61

## Check List

- [X] All tests pass. See TESTING.md for details.
- [X] New functionality includes testing.
- [X] New functionality has been documented in the README if applicable.
