### PR TITLE
Bugfix/pr-91

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+- improves resource documentation in README
+- fixes jail resource to support priority property in delete action
+
 ## 6.3.0 - *2020-12-01*
 
 - Remove deprecated platform in spec tests

--- a/README.md
+++ b/README.md
@@ -121,22 +121,28 @@ Then you will get notifications like this:
 
 ## Resources
 
-There are 2 resources you can use to create `fail2ban_filter` and `fail2ban_jail`.
-
 ### fail2ban_filter
 
-The filter resource manages custom filters that are stored in `/etc/fail2ban/filters.d/`.
+Manages fail2ban filters in `/etc/fail2ban/filters.d/`.
 
-#### Parameters
+#### Actions
 
-fail2ban_filter accepts the following parameters:
+- `create` - Default. Creates a fail2ban filter.
+- `delete` - Deletes a fail2ban filter.
 
-- failregex
-- ignoreregex
+#### Properties
 
-Example:
+- `filter` - Specifies the name of the filter. This is the name property.
+- `source` - Specifies the template source. By default, this is set to `filter.erb`.
+- `cookbook` - Specifies the template cookbook. By default, this is set to `fail2ban`.
+- `failregex` - Specifies one or multiple regular expressions matching the failure.
+- `ignoreregex` - Specifies one or multiple regular expressions to ignore.
 
-```
+#### Examples
+
+Configure a file for webmin authentication with multiple regular expressions matching the failure.
+
+```ruby
 fail2ban_filter 'webmin-auth' do
   failregex ["^%(__prefix_line)sNon-existent login as .+ from <HOST>\s*$",
              "^%(__prefix_line)sInvalid login as .+ from <HOST>\s*$"]
@@ -145,22 +151,30 @@ end
 
 ### fail2ban_jail
 
-The filter resource manages custom jail definitions that are stored in `/etc/fail2ban/jail.d/`.
+Manages fail2ban jails in `/etc/fail2ban/jail.d/`.
 
-### Parameters
+#### Actions
 
-fail2ban_jail accepts the following parameters:
+- `create` - Default. Creates a fail2ban jail.
+- `delete` - Deletes a fail2ban jail.
 
-- filter - Name of the filter to be used by the jail to detect matches.
-- logpath -  Path to the log file which is provided to the filter.
-- protocol - Protocol type [tcp, udp, all]. TCP Default.
-- ports - An array of port(s) to watch.
-- maxretry - Number of matches which triggers ban action.
-- ignoreips - An array of IPs to ignore.
+#### Properties
 
-Example:
+- `jail` - Specifies the jail name. This is the name property.
+- `source` - Specifies the template source. By default, this is set to `jail.erb`.
+- `cookbook` - Specifies the template cookbook. By default, this is set to `fail2ban`.
+- `filter` - Specifies the name of the filter to be used by the jail to detect matches.
+- `logpath` - Specifies the path to the log file which is provided to the filter.
+- `protocol` - Specifies the protocol type, e.g. tcp, udp or all.
+- `ports` - Specifies an array of port(s) to watch.
+- `maxretry` - Specifies the number of matches which triggers ban action.
+- `ignoreips` - Specifies an array of IP addresses to ignore.
 
-```
+#### Examples
+
+Create a new fail2ban jail for SSH that uses existing filter `sshd` and which bans client after 3 tries.
+
+```ruby
 fail2ban_jail 'ssh' do
   ports %w(ssh)
   filter 'sshd'

--- a/resources/filter.rb
+++ b/resources/filter.rb
@@ -31,8 +31,10 @@ action :create do
     owner 'root'
     group 'root'
     mode '0644'
-    variables failregex: new_resource.failregex,
-              ignoreregex: new_resource.ignoreregex
+    variables(
+      failregex: new_resource.failregex,
+      ignoreregex: new_resource.ignoreregex
+    )
     notifies :reload, 'service[fail2ban]'
   end
 end

--- a/resources/jail.rb
+++ b/resources/jail.rb
@@ -19,9 +19,9 @@
 #
 
 property :jail, String, name_property: true
-property :filter, String
 property :source, String, default: 'jail.erb'
 property :cookbook, String, default: 'fail2ban'
+property :filter, String
 property :logpath, String
 property :protocol, String
 property :ports, Array, default: []
@@ -36,19 +36,21 @@ action :create do
     owner 'root'
     group 'root'
     mode '0644'
-    variables name: new_resource.jail,
-              filter: new_resource.filter,
-              logpath: new_resource.logpath,
-              protocol: new_resource.protocol,
-              ports: new_resource.ports,
-              maxretry: new_resource.maxretry,
-              ignoreips: new_resource.ignoreips
+    variables(
+      name: new_resource.jail,
+      filter: new_resource.filter,
+      logpath: new_resource.logpath,
+      protocol: new_resource.protocol,
+      ports: new_resource.ports,
+      maxretry: new_resource.maxretry,
+      ignoreips: new_resource.ignoreips
+    )
     notifies :reload, 'service[fail2ban]'
   end
 end
 
 action :delete do
-  file "/etc/fail2ban/jail.d/50-#{new_resource.jail}.conf" do
+  file "/etc/fail2ban/jail.d/#{new_resource.priority}-#{new_resource.jail}.conf" do
     action :delete
     notifies :reload, 'service[fail2ban]'
   end


### PR DESCRIPTION
# Description

Fixes missing `priority` property in action `delete` of resource `fail2ban_jail`. Without this change, the property `priorty` will be ignored during `delete` action, as the resource deletes a file with priority `50` only. Additionally this PR improves the resource documentation in README and provides some polishing.

This PR is an addition to PR #91 which fixes #60 and #61.

## Issues Resolved

* #91 

## Check List

- [x] All tests pass. See TESTING.md for details.
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable.
