### PR TITLE
Fix jail template to not set `port` or `logpath` if not defined in the resource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+- Fix jail template to not set `port` or `logpath` if not defined in the resource
+
 ## 6.3.1 - *2020-12-09*
 
 - improves resource documentation in README

--- a/templates/jail.erb
+++ b/templates/jail.erb
@@ -5,9 +5,13 @@ enabled = true
 <% if @protocol -%>
 protocol = <%= @protocol %>
 <% end -%>
+<% unless @ports.empty? -%>
 port = <%= @ports.join(",") %>
+<% end -%>
 filter = <%= @filter %>
+<% if @logpath -%>
 logpath = <%= @logpath %>
+<% end -%>
 <% if @maxretry -%>
 maxretry = <%= @maxretry %>
 <% end -%>


### PR DESCRIPTION
Setting the `port` or `logpath` isn't required, especially on modern systems which automatically have this setup if you're using the included filters. Having these set to nothing causes problems with iptable rules being set properly.

Signed-off-by: Lance Albertson <lance@osuosl.org>
