### PR TITLE
Disable EPEL for Amazon Linux 2023

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+- Amazon Linux 2023 does not officially support EPEL nor is it required for the fail2ban package
+
 ## 7.0.24 - *2024-11-18*
 
 Standardise files with files in sous-chefs/repo-management

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -79,3 +79,8 @@ if platform_family?('rhel', 'fedora', 'amazon')
     'enabled' => false,
   }
 end
+
+if platform?('amazon') && platform_version.to_i >= 2023
+  default['yum']['epel']['enabled'] = false
+  default['yum']['epel']['make_cache'] = false
+end


### PR DESCRIPTION
# Description

Disable EPEL for Amazon Linux 2023. [Amazon Linux 2023 does not officially support EPEL](https://docs.aws.amazon.com/linux/al2023/ug/epel.html) nor is it required for the fail2ban package.

```
$ sudo yum list fail2ban
Last metadata expiration check: 0:01:06 ago on Tue Jan  7 21:30:50 2025.
Available Packages
fail2ban.noarch                                                                1.1.0-1.amzn2023.0.1                                                                 amazonlinux
```

## Issues Resolved

List any existing issues this PR resolves

## Check List

- [x] A summary of changes made is included in the CHANGELOG under `## Unreleased`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
