### PR TITLE
feat: allow define node['fail2ban']['ignoreip'] as array

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+Allow `node['fail2ban']['ignoreip']` attribute be defined as either a String or an Array.
+
 ## 7.0.24 - *2024-11-18*
 
 Standardise files with files in sous-chefs/repo-management

--- a/templates/jail.conf.erb
+++ b/templates/jail.conf.erb
@@ -15,7 +15,7 @@
 [DEFAULT]
 
 # "ignoreip" can be an IP address, a CIDR mask or a DNS host
-ignoreip = <%= node['fail2ban']['ignoreip']  %>
+ignoreip = <%= node['fail2ban']['ignoreip'].is_a?(Array) ? node['fail2ban']['ignoreip'].join(' ') : node['fail2ban']['ignoreip']  %>
 findtime = <%= node['fail2ban']['findtime'] %>
 bantime  = <%= node['fail2ban']['bantime'] %>
 maxretry = <%= node['fail2ban']['maxretry'] %>

--- a/test/cookbooks/test/recipes/default.rb
+++ b/test/cookbooks/test/recipes/default.rb
@@ -1,5 +1,7 @@
 apt_update
 
+node.default['fail2ban']['ignoreip'] =  %w(1.2.3.4 5.6.7.8)
+
 include_recipe 'openssh'
 include_recipe 'rsyslog'
 include_recipe 'fail2ban'

--- a/test/integration/default/inspec/default_spec.rb
+++ b/test/integration/default/inspec/default_spec.rb
@@ -3,3 +3,12 @@ describe service('fail2ban') do
   it { should be_enabled }
   it { should be_running }
 end
+
+describe file('/etc/fail2ban/jail.local') do
+  it { should exist }
+  its(:size) { should > 0 }
+  it { should be_owned_by 'root' }
+  it { should be_grouped_into 'root' }
+  its(:mode) { should cmp '0644' }
+  its('content') { should match %r{^ignoreip = 1\.2\.3\.4\s5\.6\.7\.8$} }
+end


### PR DESCRIPTION
# Description

This allows to define `node['fail2ban']['ignoreip']` also as an array. This way users of `default` recipe may make use of [deep merge](https://docs.chef.io/attribute_arrays/) of attributes and not be required to re-define this attribute in nested chef roles.

'deep merge' example:

_base_ chef role:
```ruby
name 'fail2ban_base'
run_list %w(
  recipe[fail2ban::default]
)

default_attributes(
  fail2ban: {
     ignoreip: %w(1.2.3.4)
     ...
  }
)

```
Then in _another_ chef role:
```ruby
name 'fail2ban_extend'

run_list %w(
  role[fail2ban_base]
)

default_attributes(
  fail2ban: {
     ignoreip: %w(5.6.7.8)
     ...
  }
```
results to: `node['fail2ban']['ignoreip'] = [ '1.2.3.4', '5.6.7.8' ]`


## Issues Resolved

None.

## Check List

- [x] A summary of changes made is included in the CHANGELOG under `## Unreleased`
- [-] New functionality includes testing.
- [-] New functionality has been documented in the README if applicable.
